### PR TITLE
Ga refactor

### DIFF
--- a/event-layer.js
+++ b/event-layer.js
@@ -143,39 +143,19 @@ var EventLayer = (function EventLayer () {
             test: function () {
                 return window.ga && window.ga.loaded;
             },
-            identify: function (userId, userProperties) {
+            identify: function (userId, userProperties = {}) {
                 if (window.ga) {
-                    var tracker;
-
-                    try {
-                        tracker = ga.getAll()[0];
-                    } catch(e){}
-
-                    if (tracker) {
-                        tracker.send('set', 'userId', userId);
-                    } else {
-                        ga('set', 'userId', userId);
-                    }
+                    userProperties.userId = userId
+                    ga('set', userProperties);
                 }
             },
             track: function (eventName, eventProperties = {}) {
                 if (window.ga) {
-                    
                     if (!eventProperties.hasOwnProperty("eventCategory")) {
                         eventProperties.eventCategory = "All"
                     }
                     eventProperties.eventAction = eventName;
-
-                    var tracker;
-                    try {
-                        tracker = ga.getAll()[0];
-                    } catch(e){}
-
-                    if (tracker) {
-                        tracker.send('event', eventProperties);
-                    } else {
-                        ga('send', 'event', eventProperties);
-                    }
+                    ga('send', 'event', eventProperties);
                 }
             }
         },

--- a/event-layer.js
+++ b/event-layer.js
@@ -164,6 +164,7 @@ var EventLayer = (function EventLayer () {
                     if (!eventProperties.hasOwnProperty("eventCategory")) {
                         eventProperties.eventCategory = "All"
                     }
+                    eventProperties.eventAction = eventName;
 
                     var tracker;
                     try {

--- a/event-layer.js
+++ b/event-layer.js
@@ -155,34 +155,17 @@ var EventLayer = (function EventLayer () {
                         eventProperties.eventCategory = "All"
                     }
                     eventProperties.eventAction = eventName;
-                    ga('send', 'event', eventProperties);
+                    eventProperties.hitType = 'event'
+                    ga('send', eventProperties);
                 }
             },
-            page: function (category, name, properties) {
+            page: function (category, name, properties={}) {
                 if (window.ga) {
-                    var tracker;
-
-                    try {
-                        tracker = ga.getAll()[0];
-                    } catch(e){}
-
-                    // See: https://developers.google.com/analytics/devguides/collection/analyticsjs/pages
-
                     if (category) properties.category = category;
                     properties.hitType = 'pageview';
                     properties.page = name || properties.path;
                     properties.location = properties.url;
-
-                    if (tracker) {
-                        tracker.set(properties);
-                        tracker.send(properties);
-                    } else {
-                        ga('set', properties);
-                        ga('send', properties);
-                    }
-
-                    // Default (Simpler) approach used by GA default code snippet:
-                    // ga('send', 'pageview');
+                    ga('send', properties);
                 }
             }
         },

--- a/event-layer.js
+++ b/event-layer.js
@@ -158,26 +158,22 @@ var EventLayer = (function EventLayer () {
                     }
                 }
             },
-            track: function (eventName, eventProperties) {
+            track: function (eventName, eventProperties = {}) {
                 if (window.ga) {
-                    var tracker;
+                    
+                    if (!eventProperties.hasOwnProperty("eventCategory")) {
+                        eventProperties.eventCategory = "All"
+                    }
 
+                    var tracker;
                     try {
                         tracker = ga.getAll()[0];
                     } catch(e){}
 
                     if (tracker) {
-                        tracker.send('event', {
-                            hitType: 'event',
-                            eventCategory: 'All',
-                            eventAction: eventName
-                        });
+                        tracker.send('event', eventProperties);
                     } else {
-                        ga('send', {
-                            hitType: 'event',
-                            eventCategory: 'All',
-                            eventAction: eventName
-                        });
+                        ga('send', 'event', eventProperties);
                     }
                 }
             }


### PR DESCRIPTION
Google generally recomends to work directly with the ga queue. For people using more than one tracker this could be different, but that case isn't particularly covered in the current implementation, that's why I propose to simplify these functions. 
Happy to hear alternatives or counterviews.

best,
J